### PR TITLE
Adds Github Action for Building and Publishing Docker Image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  [push]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pedropaf/zpass
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ How does zpass3 works?
 zpass3 uses modern cryptography to combine your master password with an identifier of the website or app you want to login into and outputs a password.
 Given the same combination of __master password__ and __identifier__ zpass3 will output the same __password__.
 
+Running Docker Image
+----------
+To build and run the image locally run:
+
+`docker run -p 8080:80 [container_name]`
+
 How secure is it?
 -----------------
 The cryptographic function used by zpass3 is called __SCrypt__ and is used to secure all kinds of applications inclusive in Crypto Currency.


### PR DESCRIPTION
1. Adds Github Action for Building and Publishing Docker Image on Docher Hub every time code is pushed

Requires that the following secret variables are set on Github:
DOCKER_USERNAME
DOCKER_PASSWORD
DOCKER_LOCATION (e.g. 'pedropaf/zpass')

2. Adds intstructions for local building and running the docker on README.md

CAVEAT/TODO:
Publishing on "push" is unatural and labels the release as the name of the branch
A more intentional way to do this seems to be on_release so that the docker image is organized by release number
